### PR TITLE
add `cocoapods support` document

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,13 @@ Xcode "build post-action" (Recommended)
     .. code-block:: bash
 
       $ python2 -mxUnique "${PROJECT_FILE_PATH}/project.pbxproj"
-
+      
+    if you use `Cocoapods <http://cocoapods.org/>`__, add the extra following commands:
+    
+    .. code-block:: bash
+    
+      $ python2 -mxUnique "${PODS_ROOT}/Pods.xcodeproj/project.pbxproj"
+      
 #.  click ``Close`` and it's all done.
 #.  Next time when you Build or Run the project, xUnique would be
     triggered after build success. If the build works, you could commit


### PR DESCRIPTION
[Cocoapods](http://cocoapods.org/) is a common tool for iOS development stuff,  adding "cocoapods support document" makes sense of convenience for preventing being confused to many developers I think.