### PR TITLE
Provides a console script for xunique.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,8 @@ setup(
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7'
     ],
+    entry_points="""
+        [console_scripts]
+        xunique=xUnique:cli
+        """,
 )

--- a/xUnique.py
+++ b/xUnique.py
@@ -518,6 +518,8 @@ def main(sys_args):
         if xunique.is_modified:
             warning_print("File 'project.pbxproj' was modified, please add it and commit again to submit xUnique result.\nNOTICE: If you want to submit xUnique result combined with original commit, use option '-c' in command.")
 
+def cli():
+    main(sys_argv)
 
 if __name__ == '__main__':
-    main(sys_argv)
+    cli()


### PR DESCRIPTION
Adds a console script entry point to setup.py
Adds a new `cli` function to xUnique.py that takes zero parameters and
calls straight into main() with sys argue.

(The purpose of this is to allow easy installation and execution of xunique for people not too familiar with python, or who don't want to track down where xUnique.py was called from)