### PR TITLE
Properly handle missing fields

### DIFF
--- a/xUnique.py
+++ b/xUnique.py
@@ -137,7 +137,7 @@ Please check:
         current_node = self.nodes[current_hex]
         isa_type = current_node['isa']
         if isinstance(current_path_key, (list, tuple)):
-            current_path = '/'.join([six.text_type(current_node[i]) for i in current_path_key])
+            current_path = '/'.join([six.text_type(current_node.get(i, isa_type)) for i in current_path_key])
         elif isinstance(current_path_key, six.string_types):
             if current_path_key in current_node.keys():
                 current_path = current_node[current_path_key]


### PR DESCRIPTION
CocoaPods 1.6 is writing a new PBXAggregateTarget section which contains node without `productName` key. As a result running xUnique against the Pods.xcodeproj resulted in the following error:

``` 
  File "build/bdist.macosx-10.12-intel/egg/xUnique.py", line 140, in __set_to_result
KeyError: u'productName'
```

The fix modifies the `__set_to_result` method making it (naively) resilient to the missing key.