### PR TITLE
docs: fix simple typo, inlcuding -> including

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ What it does & How it works
 
 #. Replace all old UUIDs with the MD5 hex digest and also remove unused
    UUIDs that are not in the current node tree and UUIDs in wrong format
-#. Sort the project file inlcuding ``children``, ``files``,
+#. Sort the project file including ``children``, ``files``,
    ``PBXFileReference`` and ``PBXBuildFile`` list and remove all
    duplicated entries in these lists
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `including` rather than `inlcuding`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md